### PR TITLE
update dustdas version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -11,7 +11,7 @@ intervaltree
 numpy
 h5py
 multiprocess
-git+https://github.com/janinamass/dustdas@master
+git+https://github.com/gglyptodon/dustdas@v0.2
 numcodecs
 appdirs
 # for testing only


### PR DESCRIPTION
Just fyi: I moved the dustdas repo to https://github.com/gglyptodon/dustdas/ and made a v0.2 tag/release that is now referenced in the requirements.txt 