### PR TITLE
modernize by moving most package metadata to pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools"]
+requires = ["setuptools >= 61.0"]
 build-backend = "setuptools.build_meta"
 
 [project]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,48 @@
+[build-system]
+requires = ["setuptools"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "helixer"
+version = "0.3.3"
+description = "Deep Learning fun on gene structure data"
+readme = "README.md"
+requires-python = ">=3.8.5"
+classifiers = [
+    "Programming Language :: Python :: 3",
+    "Operating System :: POSIX :: Linux",
+    "License :: OSI Approved :: GNU General Public License v3 (GPLv3)",
+]
+dependencies = [
+    "geenuff @ git+https://github.com/weberlab-hhu/GeenuFF@v0.3.2",
+    "sqlalchemy==1.3.22",
+    "tensorflow>=2.6.2",
+    "tensorflow-addons>=0.21.0",
+    "nni",
+    "seaborn",
+    "Keras<3.0.0",
+    "keras_layer_normalization",
+    "terminaltables",
+    "HTSeq",
+    "intervaltree",
+    "numpy",
+    "h5py",
+    "multiprocess",
+    "numcodecs",
+    "appdirs"
+]
+
+[project.urls]
+"Homepage" = "https://github.com/weberlab-hhu/Helixer"
+"Documentation" = "https://github.com/weberlab-hhu/Helixer"
+
+[tool.setuptools]
+packages = [
+    "helixer",
+    "helixer.core",
+    "helixer.prediction",
+    "helixer.evaluation",
+    "helixer.tests",
+    "helixer.export"
+]
+package-data = {helixer = ["testdata/*.fa", "testdata/*.gff"]}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools >= 61.0"]
+requires = ["setuptools < 72.0"]
 build-backend = "setuptools.build_meta"
 
 [project]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,3 +46,4 @@ packages = [
     "helixer.export"
 ]
 package-data = {helixer = ["testdata/*.fa", "testdata/*.gff"]}
+script-files = ["Helixer.py", "fasta2h5.py", "geenuff2h5.py", "helixer/prediction/HybridModel.py", "scripts/fetch_helixer_models.py"]

--- a/setup.py
+++ b/setup.py
@@ -1,28 +1,6 @@
 from setuptools import setup
 
 setup(
-   name='helixer',
-   version='0.3.3',
-   description='Deep Learning fun on gene structure data',
-   packages=['helixer', 'helixer.core', 'helixer.prediction', 'helixer.evaluation', 'helixer.tests', 'helixer.export'],
-   package_data={'helixer': ['testdata/*.fa', 'testdata/*.gff']},
-   install_requires=["geenuff @ git+https://github.com/weberlab-hhu/GeenuFF@v0.3.2",
-                     "sqlalchemy==1.3.22",
-                     "tensorflow>=2.6.2",
-                     "tensorflow-addons>=0.21.0",
-                     "nni",
-                     "seaborn",
-                     "Keras<3.0.0",
-                     "keras_layer_normalization",
-                     "terminaltables",
-                     "HTSeq",
-                     "intervaltree",
-                     "numpy",
-                     "h5py",
-                     "multiprocess",
-                     "numcodecs",
-                     "appdirs",
-                    ],
    scripts=["Helixer.py", "fasta2h5.py", "geenuff2h5.py", "helixer/prediction/HybridModel.py", "scripts/fetch_helixer_models.py"],
    zip_safe=False,
 )

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,3 @@
 from setuptools import setup
 
-setup(
-   scripts=["Helixer.py", "fasta2h5.py", "geenuff2h5.py", "helixer/prediction/HybridModel.py", "scripts/fetch_helixer_models.py"],
-   zip_safe=False,
-)
+setup(zip_safe=False)


### PR DESCRIPTION
This pull request transfers most of the package metadata to a pyproject.toml file, the format which is [arguably preferred](https://packaging.python.org/en/latest/guides/modernize-setup-py-project/) for modern Python packages. A few new metadata fields are added: `readme`, `requires-python`, `classifiers`, and `project.urls`.

This change would be a good step to take before [uploading](https://packaging.python.org/en/latest/tutorials/packaging-projects/) helixer to PyPI. Uploading to PyPI would make it much more convenient to create a Bioconda recipe for helixer, which has been requested a [couple of times](https://github.com/weberlab-hhu/Helixer/issues?q=is%3Aissue+is%3Aopen+bioconda).